### PR TITLE
Merge devtest: Add NVIDIA driver automation, InfiniBand support, and collapsible benchmarks

### DIFF
--- a/hpctests.sh
+++ b/hpctests.sh
@@ -711,6 +711,8 @@ check_and_install_dependencies() {
         [ibstatus]="ibutils" [ibdev2netdev]="ibutils" [iblinkinfo]="ibutils"
         [speedtest-cli]="speedtest-cli" [lsb_release]="lsb-release" [ssh-keygen]="openssh-client"
     )
+    # Packages to always install (checked by dpkg, not by command availability)
+    local required_packages=("infiniband-diags" "rdma-core")
     declare -A complex_commands
     complex_commands=(
         [nvidia-smi]="NVIDIA drivers" [nv-fabricmanager]="NVIDIA Fabric Manager" [ofed_info]="Mellanox OFED drivers"
@@ -737,6 +739,14 @@ check_and_install_dependencies() {
             local package=${standard_packages[$cmd]}
             if [[ ! " ${packages_to_install[@]} " =~ " ${package} " ]]; then
                 packages_to_install+=("$package")
+            fi
+        fi
+    done
+    # Add required packages that should always be installed
+    for pkg in "${required_packages[@]}"; do
+        if ! dpkg -l | grep -q "^ii  $pkg "; then
+            if [[ ! " ${packages_to_install[@]} " =~ " ${pkg} " ]]; then
+                packages_to_install+=("$pkg")
             fi
         fi
     done

--- a/hpctests.sh
+++ b/hpctests.sh
@@ -1385,6 +1385,22 @@ run_software_tests() {
 # Main Execution Logic
 # ==============================================================================
 
+check_and_handle_nvidia_drivers() {
+    log "Checking for NVIDIA drivers..."
+    if check_nvidia_drivers; then
+        log_success "NVIDIA drivers are installed and configured."
+    else
+        log_warn "NVIDIA drivers not detected on system."
+        if $NOINSTALL_MODE; then
+            log_warn "--noinstall specified: skipping NVIDIA driver installation."
+        elif $NOCHECK_MODE; then
+            log_warn "--nocheck specified: skipping NVIDIA driver checks."
+        else
+            install_nvidia_drivers
+        fi
+    fi
+}
+
 main() {
     if [[ $EUID -ne 0 ]]; then
        log_error "This script must be run as root or with sudo."; exit 1
@@ -1424,6 +1440,7 @@ main() {
         log_warn "Running in --nocheck mode. All dependency checks and prompts will be skipped."
     else
         check_and_install_dependencies
+        check_and_handle_nvidia_drivers
     fi
 
     log "Starting all tests. The results will be saved to: ${C_YELLOW}${OUTPUT_FILE}${C_RESET}"

--- a/hpctests.sh
+++ b/hpctests.sh
@@ -1264,6 +1264,9 @@ run_benchmark_tests() {
                 add_row_to_html_report "Benchmarks" "N/A" "Skipped - Docker not installed" "partial" "User skipped installation"; close_html_category_section; return;
             fi
         fi
+    else
+        log "Docker is installed. Setting up NVIDIA Container Toolkit..."
+        setup_nvidia_container_toolkit
     fi
     
     local choice


### PR DESCRIPTION
## Summary
This PR merges all improvements developed in the devtest branch today, including comprehensive NVIDIA driver support, automatic InfiniBand package installation, and enhanced reporting features.

## Changes Included

### NVIDIA Driver Management
- Automatic detection of NVIDIA drivers with version reporting (driver, CUDA, Fabric Manager)
- Automatic installation flow with ubuntu-drivers and version-configurable packages
- Post-reboot recovery with marker file and Fabric Manager verification
- Configurable via NVIDIA_DRIVER_VERSION and NVIDIA_FABRICMANAGER_VERSION env vars

### Container Support
- Automatic NVIDIA Container Toolkit setup after Docker detection/installation
- Enables GPU access in Docker containers before running benchmarks

### InfiniBand Support
- Auto-install infiniband-diags and rdma-core packages
- Collapsible view for IB Fabric output in HTML report
- Enhanced fabric topology testing

### Benchmark Improvements
- Real-time console output for HPL and GPU Burn tests
- Collapsible views for detailed benchmark results in HTML reports
- Updated HPL command with enhanced Docker parameters

### Documentation
- Updated README with new features and environment variables
- Added configuration examples for thresholds and server pinning
- Documented automatic installation workflows

## Co-Author
Co-Authored-By: Warp <agent@warp.dev>